### PR TITLE
Ensure PlayQueueTools remain at bottom of viewport

### DIFF
--- a/app/components/play-queue-tools/styles.scss
+++ b/app/components/play-queue-tools/styles.scss
@@ -1,13 +1,20 @@
 .play-queue-tools {
-  margin: 10px 15px;
+  margin: 0;
+  position: fixed;
+  bottom: 10px;
+
   &__tool {
     width: 43px;
-    height: 43px;
+    height: 15px;
     display:inline-block;
     background-position: center;
     background-repeat: no-repeat;
     vertical-align:middle;
     cursor:pointer;
+
+    &:first-of-type {
+      margin-left: 10px;
+    }
   }
 
   &__shuffle, &__repeat {


### PR DESCRIPTION
Use position fixed to ensure that the play queue tools always sit at the bottom of the viewport