### PR TITLE
Home to Album page render

### DIFF
--- a/app/components/album/index.js
+++ b/app/components/album/index.js
@@ -35,35 +35,43 @@ export class Album extends React.Component {
 
   componentDidMount() {
     if (this.props.params.mbid) {
-      this.props.onGetAlbumPageData({ mbid: this.props.params.mbid});
+      this.getAlbumDataByMbid(this.props.params.mbid);
     } else {
-      this.props.onGetAlbumPageData({
-        artist: this.props.params.artist, 
-        album: this.props.params.album
-      });
+      this.getAlbumPageName(
+        this.props.params.artist, 
+        this.props.params.album
+      );
     }
   }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.params.mbid) {
       if(nextProps.params.mbid !== this.props.params.mbid) {
-        // TODO:  investigate whether getAlbumPageDat action creator
-        // can use a thunk as well as using promise middleware
-        // if so we can just dispatch one action instead of three here
-        this.props.onClearAlbumPageData();
-        this.props.onClearAlbumPageError();
-        this.props.onGetAlbumPageData({ mbid: nextProps.params.mbid});
+        this.getAlbumDataByMbid(nextProps.params.mbid);
       }
     } else if (nextProps.params.album !== this.props.params.album) {
-      this.props.onClearAlbumPageData();
-      this.props.onClearAlbumPageError();
-      this.props.onGetAlbumPageData({
-        artist: nextProps.params.artist, 
-        album: nextProps.params.album
-      });
+      this.getAlbumPageName(nextProps.params.artist, nextProps.params.album);
     }
   }
-   
+  
+  getAlbumDataByMbid(mbid) {
+    // TODO:  investigate whether getAlbumPageDat action creator
+    // can use a thunk as well as using promise middleware
+    // if so we can just dispatch one action instead of three here
+    this.props.onClearAlbumPageData();
+    this.props.onClearAlbumPageError();
+    this.props.onGetAlbumPageData({ mbid: mbid});
+  }
+
+  getAlbumDataByName(artist, album) {
+    this.props.onClearAlbumPageData();
+    this.props.onClearAlbumPageError();
+    this.props.onGetAlbumPageData({
+      artist: artist, 
+      album: album
+    });
+  }
+
   // TODO : Break out in to a separate Tracks component
   renderTracks() {
     if(this.props.albumPageData.tracks) {


### PR DESCRIPTION
When moving between the home and album routes ensure that the previous album page content is cleared before displaying new content.